### PR TITLE
Fix pyproject license and formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,44 +1,47 @@
 [build-system]
-requires = ["hatchling"]
 build-backend = "hatchling.build"
+requires = [ "hatchling" ]
 
 [project]
 name = "imdb-data"
 version = "0.1.0"
 readme = "README.md"
-authors = [{ name = "Joshua Peek" }]
+license-files = [ "LICENSE" ]
+authors = [ { name = "Joshua Peek" } ]
 requires-python = ">=3.10"
-dependencies = [
-    "click>=8.0.0,<9.0",
-    "parsel>=1.0.0,<2.0",
-    "requests>=2.0.0,<3.0",
-]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
+]
+dependencies = [
+    "click>=8,<9",
+    "parsel>=1,<2",
+    "requests>=2,<3",
+]
+scripts.imdb-data = "imdb_data:main"
+
+license-expression = "MIT"
+
+[dependency-groups]
+dev = [
+    "mypy>=1,<2",
+    "ruff>=0.5",
+    "types-requests>=2,<3",
 ]
 
 [tool.hatch.build.targets.wheel.force-include]
 "imdb_data.py" = "imdb_data/__init__.py"
 
-[project.scripts]
-imdb-data = "imdb_data:main"
+[tool.ruff]
+lint.extend-select = [ "I", "UP" ]
 
-[dependency-groups]
-dev = [
-    "mypy>=1.0.0,<2.0",
-    "ruff>=0.5.0",
-    "types-requests>=2.0.0,<3.0",
-]
-
-[tool.ruff.lint]
-extend-select = ["I", "UP"]
+[tool.pyproject-fmt]
+indent = 4
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
## Summary
- switch to PEP 639 license-expression field and keep license file
- run `pyproject-fmt` with 4 space indent rule
- remove excess blank lines in `pyproject.toml`

## Testing
- `uv run ruff format --diff pyproject.toml`
- `uv run ruff check .`
- `uv run mypy .`


------
https://chatgpt.com/codex/tasks/task_e_6876954fab78832694f2a60e568d2686